### PR TITLE
fix(delta): nest configuration under programs.git for Home Manager compatibility

### DIFF
--- a/modules/home-manager/delta.nix
+++ b/modules/home-manager/delta.nix
@@ -11,15 +11,13 @@ in
   options.programs.git.delta.tokyonight = lib.tn.mkTokyonightOpt "tokyonight git delta";
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
-      programs = {
+      programs.git = {
         delta.options.features = "tokyonight_${cfg.style}";
-        git = {
-          includes = [
-            {
-              path = "${inputs.tokyonight}/extras/delta/tokyonight_${cfg.style}.gitconfig";
-            }
-          ];
-        };
+        includes = [
+          {
+            path = "${inputs.tokyonight}/extras/delta/tokyonight_${cfg.style}.gitconfig";
+          }
+        ];
       };
     })
   ];


### PR DESCRIPTION
Fixes #6

## Problem
  The delta configuration refactor in 85aa747 sets `delta.options.features` at the top level, which creates the path `config.delta.options.features`. This option doesn't exist in Home Manager, causing the error:

The option `home-manager.users."".programs.delta' does not exist.

## Solution
  Nest the delta configuration under `programs.git` to create the correct path
  `config.programs.git.delta.options.features`, which is the valid Home Manager option structure.