### PR TITLE
fix: Update fzf.nix to change deprecated `zsh.initExtra` option

### DIFF
--- a/modules/home-manager/fzf.nix
+++ b/modules/home-manager/fzf.nix
@@ -45,7 +45,7 @@ in
           # these are .zsh files, but the syntax is compatible
           fish.interactiveShellInit = shell_theme;
           bash.initExtra = shell_theme;
-          zsh.initExtra = shell_theme;
+          zsh.initContent = shell_theme;
         };
     })
   ];


### PR DESCRIPTION
The module uses `zsh.initExtra` which is
  deprecated in Home Manager 25.11 and master.


- https://github.com/nix-community/home-manager/pull/6664

```
• Added input 'treefmt-nix/nixpkgs':
    'github:nixos/nixpkgs/d5faa84122bc0a1fd5d378492efce4e289f8eac1?narHash=sha256-%2Bpthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE%2BfV2Q%3D' (2025-10-23)
evaluation warning: `programs.zsh.initExtra` is deprecated, use `programs.zsh.initContent` instead.

                    Example: programs.zsh.initContent = "your content here";
these 19 derivations will be built:
```