### PR TITLE
fix(nix): Renamed neovim.extraLuaConfig to neovim.initLua

### DIFF
--- a/modules/home-manager/neovim.nix
+++ b/modules/home-manager/neovim.nix
@@ -26,7 +26,7 @@ in {
     (lib.mkIf cfg.enable {
       programs.neovim = {
         plugins = [ pkgs.vimPlugins.tokyonight-nvim ];
-        extraLuaConfig = ''
+        initLua = ''
           ${if builtins.hasAttr "extraLua"
           config.programs.neovim.tokyonight then
             config.programs.neovim.tokyonight.extraLua


### PR DESCRIPTION
Option extraLuaConfig was renamed to initLua in neovim configurations so this pull request should fix warning which appear.